### PR TITLE
test_pickle Fix

### DIFF
--- a/Include/pybuffer.h
+++ b/Include/pybuffer.h
@@ -15,7 +15,6 @@ extern "C" {
  * struct layout and size must not be changed in any way, as it would
  * break the ABI.
  *
- * XXX-AM: CHERI breaks the stable abi3 here.
  */
 
 typedef struct {
@@ -24,14 +23,13 @@ typedef struct {
     Py_ssize_t len;
     Py_ssize_t itemsize;  /* This is Py_ssize_t so it can be
                              pointed to by strides in simple case.*/
+    int readonly;
+    int ndim;
     char *format;
     Py_ssize_t *shape;
     Py_ssize_t *strides;
     Py_ssize_t *suboffsets;
     void *internal;
-    int readonly;
-    int ndim;
-    int _pad[2];
 } Py_buffer;
 
 typedef int (*getbufferproc)(PyObject *, Py_buffer *, int);

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -229,7 +229,7 @@ class BaseTest:
         bi = a.buffer_info()
         self.assertIsInstance(bi, tuple)
         self.assertEqual(len(bi), 2)
-        self.assertIsInstance(bi[0], nativepointer)
+        self.assertIsInstance(bi[0], _native_pointer)
         self.assertIsInstance(bi[1], int)
         self.assertEqual(bi[1], len(a))
 

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -343,7 +343,7 @@ if has_c_implementation:
                 0)  # Write buffer is cleared after every dump().
 
         def test_unpickler(self):
-            basesize = support.calcobjsize('2P2n2P 2P2n5P4i 2P4n8P2n4i')
+            basesize = support.calcobjsize('2P2n2P 2P2n2i5P 2P3n8P2n2i')
             unpickler = _pickle.Unpickler
             P = struct.calcsize('P')  # Size of memo table entry.
             n = struct.calcsize('n')  # Size of mark table entry.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -718,8 +718,6 @@ typedef struct UnpicklerObject {
     Py_ssize_t next_read_idx;
     Py_ssize_t prefetched_idx;  /* index of first prefetched byte */
 
-    Py_ssize_t _pad0;           /* CHERI padding */
-
     PyObject *read;             /* read() method of the input stream. */
     PyObject *readinto;         /* readinto() method of the input stream. */
     PyObject *readline;         /* readline() method of the input stream. */
@@ -739,7 +737,6 @@ typedef struct UnpicklerObject {
     int proto;                  /* Protocol of the pickle loaded. */
     int fix_imports;            /* Indicate whether Unpickler should fix
                                    the name of globals pickled by Python 2.x. */
-    int _pad1[2];               /* CHERI padding */
 } UnpicklerObject;
 
 typedef struct {

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2695,13 +2695,13 @@ static Py_buffer static_buffer = {
     NULL,           /* obj */
     12,             /* len */
     1,              /* itemsize */
+    1,              /* readonly */
+    1,              /* ndim */
     "B",            /* format */
     static_shape,   /* shape */
     static_strides, /* strides */
     NULL,           /* suboffsets */
-    NULL,           /* internal */
-    1,              /* readonly */
-    1,              /* ndim */
+    NULL            /* internal */
 };
 
 static PyObject *

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1287,13 +1287,13 @@ test_from_contiguous(PyObject* self, PyObject *Py_UNUSED(ignored))
         NULL,
         5 * itemsize,
         itemsize,
+        1,
+        1,
         NULL,
         &shape,
         &strides,
         NULL,
-        NULL,
-        1,
-        1
+        NULL
     };
     int *ptr;
     int i;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3144,7 +3144,7 @@ _PyBuiltin_Init(PyInterpreterState *interp)
     SETBUILTIN("tuple",                 &PyTuple_Type);
     SETBUILTIN("type",                  &PyType_Type);
     SETBUILTIN("zip",                   &PyZip_Type);
-    SETBUILTIN("nativepointer",         &_PyNativePointer_Type);
+    SETBUILTIN("_native_pointer",       &_PyNativePointer_Type);
     debug = PyBool_FromLong(config->optimization_level == 0);
     if (PyDict_SetItemString(dict, "__debug__", debug) < 0) {
         Py_DECREF(debug);


### PR DESCRIPTION
This change reverts `Py_buffer` and `UnpicklerObject` struct changes, removing added padding. 

It changes the builtin `nativepointer` to `_native_pointer` to be consistent with its `tp_name`.

All test_pickle tests pass under these changes.