### PR TITLE
Remove cheri-bits argument in generate_cases.py

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -48,9 +48,6 @@ arg_parser.add_argument(
     "-l", "--emit-line-directives", help="Emit #line directives", action="store_true"
 )
 arg_parser.add_argument(
-    "--cheri-bits", help="CHERI capability bits", type=int,
-)
-arg_parser.add_argument(
     "input", nargs=argparse.REMAINDER, help="Instruction definition file(s)"
 )
 


### PR DESCRIPTION
Missed a reference to cheri-bits argument when removing it.