### PR TITLE
Fix check for cheri capability

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -168,7 +168,7 @@ class StructTest(unittest.TestCase):
         self.assertLessEqual(struct.calcsize('l'), struct.calcsize('q'))
         self.assertGreaterEqual(struct.calcsize('n'), struct.calcsize('i'))
         # XXX-AM: Enforcing sizeof(ssize_t) >= sizeof(void *) does not seem portable
-        if not hasattr(sys, "cheri_platform"):
+        if not __cheri_cap_size__:
             self.assertGreaterEqual(struct.calcsize('n'), struct.calcsize('P'))
 
     def test_integers(self):


### PR DESCRIPTION
The previous conditional would always return False so the test was always being skipped.
