### PR TITLE
Fix test default

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1397,7 +1397,7 @@ class SizeofTest(unittest.TestCase):
         samples = [b'', b'u'*100000]
         for sample in samples:
             x = bytearray(sample)
-            check(x, vsize('n2Pi') + x.__alloc__())
+            check(x, vsize('n2Pn') + x.__alloc__())
         # bytearray_iterator
         check(iter(bytearray()), size('nP'))
         # bytes

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1373,9 +1373,12 @@ class SizeofTest(unittest.TestCase):
             sys.getsizeof(OverflowSizeof(-sys.maxsize - 1))
 
     def test_default(self):
-        size = test.support.calcvobjsize
-        self.assertEqual(sys.getsizeof(True), size('') + self.longdigit)
-        self.assertEqual(sys.getsizeof(True, -1), size('') + self.longdigit)
+        size = test.support.calcobjsize
+        # XXX-JL: size include 'P' due to _PyLongValue including
+        #   uintptr_t lv_tag, which is potentially something that could
+        #   be changed to a different type
+        self.assertEqual(sys.getsizeof(True), size('P') + self.longdigit)
+        self.assertEqual(sys.getsizeof(True, -1), size('P') + self.longdigit)
 
     def test_objecttypes(self):
         # check all types defined in Objects/


### PR DESCRIPTION
Some fixes to test_sys, fixing formats for calcobjsize methods, and making boolean struct test `test_default` use calcobjsize instead of calcvobjsize.